### PR TITLE
fix: add types to verify_token and request __init__

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -137,7 +137,7 @@ class Request(transport.Request):
     .. automethod:: __call__
     """
 
-    def __init__(self, session=None):
+    def __init__(self, session: requests.Session | None = None):
         if not session:
             session = requests.Session()
 

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -137,7 +137,7 @@ class Request(transport.Request):
     .. automethod:: __call__
     """
 
-    def __init__(self, session: requests.Session | None = None):
+    def __init__(self, session: requests.Session | None = None) -> None:
         if not session:
             session = requests.Session()
 

--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -64,7 +64,7 @@ from google.auth import exceptions
 from google.auth import jwt
 from google.auth import transport
 
-from typing import Union
+from typing import Any, Mapping, Union
 
 
 # The URL that provides public certificates for verifying ID tokens issued

--- a/google/oauth2/id_token.py
+++ b/google/oauth2/id_token.py
@@ -62,6 +62,9 @@ import os
 from google.auth import environment_vars
 from google.auth import exceptions
 from google.auth import jwt
+from google.auth import transport
+
+from typing import Union
 
 
 # The URL that provides public certificates for verifying ID tokens issued
@@ -104,12 +107,12 @@ def _fetch_certs(request, certs_url):
 
 
 def verify_token(
-    id_token,
-    request,
-    audience=None,
-    certs_url=_GOOGLE_OAUTH2_CERTS_URL,
-    clock_skew_in_seconds=0,
-):
+    id_token: Union[str, bytes],
+    request: transport.Request,
+    audience: str | list[str] | None = None,
+    certs_url: str = _GOOGLE_OAUTH2_CERTS_URL,
+    clock_skew_in_seconds: int = 0,
+) -> Mapping[str, Any]:
     """Verifies an ID token and returns the decoded token.
 
     Args:


### PR DESCRIPTION
Recently, I've been using this library with mypy strict mode, which doesn't like the fact that these functions are unannotated (they're the only functions I use, and thus the only ones mypy complains about to me). I'm happy to see that this project has py.typed, so these annotations should fix the problem!